### PR TITLE
Fix for opening files from Solution Items

### DIFF
--- a/src/Helpers/ProjectHelpers.cs
+++ b/src/Helpers/ProjectHelpers.cs
@@ -16,7 +16,7 @@ namespace OpenInVsCode
                 ProjectItem item = selItem.Object as ProjectItem;
 
                 if (item != null)
-                    return item.Properties.Item("FullPath").Value.ToString();
+                    return item.GetFilePath();
 
                 Project proj = selItem.Object as Project;
 
@@ -30,6 +30,11 @@ namespace OpenInVsCode
             }
 
             return null;
+        }
+
+        public static string GetFilePath(this ProjectItem item)
+        {
+            return item.FileNames[1]; // Indexing starts from 1
         }
 
         public static string GetRootFolder(this Project project)


### PR DESCRIPTION
OpenInVsCode cannot open any files in the Solution Items section, but instead throws a NullReferenceException. They don't seem to have Properties filled in the ProjectItem object and therefore "FullPath" couldn't be retrieved for them. Changed it to use FileNames property instead.