### PR TITLE
Check for 64 bit VS Code.

### DIFF
--- a/src/Options.cs
+++ b/src/Options.cs
@@ -8,12 +8,26 @@ namespace OpenInVsCode
     public class Options : DialogPage
     {
         const string _pathToExe = @"C:\Program Files (x86)\Microsoft VS Code\Code.exe";
+        const string _pathToExe64 = @"C:\Program Files\Microsoft VS Code\Code.exe";
 
         [Category("General")]
         [DisplayName("Path to code.exe")]
         [Description("Specify the path to code.exe.")]
         [DefaultValue(_pathToExe)]
         public string PathToExe { get; set; } = _pathToExe;
+
+        public Options()
+        {
+            CheckFor64Bit();
+        }
+
+        private void CheckFor64Bit()
+        {
+            if (File.Exists(_pathToExe64))
+            {
+                PathToExe = _pathToExe64;
+            }
+        }
 
         protected override void OnApply(PageApplyEventArgs e)
         {


### PR DESCRIPTION
Added a simple check to locate the 64 bit Code.exe binary. I believe this fixes #6. 