### PR TITLE
Update expired link to marketplace.visualstudio.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,6 @@ included in the project:
   `Place 'System' directives first when sorting usings` option is enabled (checked).
 - Before committing, organize usings for each updated C# source file. Either you can
   right-click editor and select `Organize Usings > Remove and sort` OR use extension
-  like [BatchFormat](http://visualstudiogallery.msdn.microsoft.com/a7f75c34-82b4-4357-9c66-c18e32b9393e).
+  like [BatchFormat](https://marketplace.visualstudio.com/items?itemName=vs-publisher-147549.BatchFormat).
 - Before committing, run Code Analysis in `Debug` configuration and follow the guidelines
   to fix CA issues. Code Analysis commits can be made separately.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Visual Studio Code.
 [![Build status](https://ci.appveyor.com/api/projects/status/hdd4uqjdqpq0f6lf?svg=true)](https://ci.appveyor.com/project/madskristensen/openinvscode)
 
 Download the extension at the
-[VS Gallery](https://visualstudiogallery.msdn.microsoft.com/33f6f3fd-68e8-4783-b934-ece91a08d265)
+[VS Gallery](https://marketplace.visualstudio.com/items?itemName=MadsKristensen.OpeninVisualStudioCode)
 or get the
 [nightly build](http://vsixgallery.com/extension/e99dde0e-e023-410d-bc5d-3f76db71e3f0/)
 


### PR DESCRIPTION
The SSL certificate for visualstudiogallery.msdn.microsoft.com seems to have expired, so I've updated the link to redirect to marketplace.visualstudio.com.